### PR TITLE
Update docs for generating keys and provide warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Meeco Encryption Library CLI
 [![License](https://img.shields.io/npm/l/cryppo-cli.svg)](https://github.com/Meeco/cryppo-cli/blob/master/package.json)
 
 <!-- toc -->
-* [Cryppo CLI](#cryppo-cli)
-* [Usage](#usage)
-* [Commands](#commands)
-<!-- tocstop -->
+
+- [Cryppo CLI](#cryppo-cli)
+- [Usage](#usage)
+- [Commands](#commands)
+  <!-- tocstop -->
 
 # Usage
 
@@ -39,29 +40,32 @@ $ cryppo verify -P public.pem myfile.signed.txt myfile.txt
 ```
 
 <!-- usage -->
+
 ```sh-session
 $ npm install -g cryppo-cli
 $ cryppo COMMAND
 running command...
 $ cryppo (-v|--version|version)
-cryppo-cli/0.2.0 darwin-x64 node-v13.12.0
+cryppo-cli/0.2.1 darwin-x64 node-v12.4.0
 $ cryppo --help [COMMAND]
 USAGE
   $ cryppo COMMAND
 ...
 ```
+
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-* [`cryppo decrypt`](#cryppo-decrypt)
-* [`cryppo encrypt`](#cryppo-encrypt)
-* [`cryppo genkey`](#cryppo-genkey)
-* [`cryppo genkeypair`](#cryppo-genkeypair)
-* [`cryppo help [COMMAND]`](#cryppo-help-command)
-* [`cryppo sign FILE DESTINATION`](#cryppo-sign-file-destination)
-* [`cryppo verify FILE DESTINATION`](#cryppo-verify-file-destination)
+
+- [`cryppo decrypt`](#cryppo-decrypt)
+- [`cryppo encrypt`](#cryppo-encrypt)
+- [`cryppo genkey`](#cryppo-genkey)
+- [`cryppo genkeypair`](#cryppo-genkeypair)
+- [`cryppo help [COMMAND]`](#cryppo-help-command)
+- [`cryppo sign FILE DESTINATION`](#cryppo-sign-file-destination)
+- [`cryppo verify FILE DESTINATION`](#cryppo-verify-file-destination)
 
 ## `cryppo decrypt`
 
@@ -78,13 +82,13 @@ OPTIONS
   -s, --serialized=serialized          (required) serialized encrypted value
 
 EXAMPLES
-  cryppo decrypt -s 
+  cryppo decrypt -s
   "Aes256Gcm.gSAByGMq4edzM0U=.LS0tCml2OiAhYmluYXJ5IHwtCiAgaW1QL09qMWZ6eWw0cmwwSgphdDogIWJpbmFyeSB8LQogIE5SbjZUQXJ2bitNS1
   Z5M0FpZEpmWlE9PQphZDogbm9uZQo=" -k vm8CjugMda2zdjsI9W25nH-CY-84DDYoBxTFLwfKLDk=
   cryppo decrypt -s "Rsa4096.bJjV2g_RBZKeyqBr-dSjPAc3qtkTgd0=.LS0tCnt9Cg==" -p private.pem
 ```
 
-_See code: [src/commands/decrypt.ts](https://github.com/Meeco/cryppo-cli/blob/v0.2.0/src/commands/decrypt.ts)_
+_See code: [src/commands/decrypt.ts](https://github.com/Meeco/cryppo-cli/blob/v0.2.1/src/commands/decrypt.ts)_
 
 ## `cryppo encrypt`
 
@@ -105,25 +109,25 @@ EXAMPLES
   encrypt -v "hello world" -P public-key.pem
 ```
 
-_See code: [src/commands/encrypt.ts](https://github.com/Meeco/cryppo-cli/blob/v0.2.0/src/commands/encrypt.ts)_
+_See code: [src/commands/encrypt.ts](https://github.com/Meeco/cryppo-cli/blob/v0.2.1/src/commands/encrypt.ts)_
 
 ## `cryppo genkey`
 
-Generate a new (random) encryption key - printed as base64 encoded
+Generate a new encryption key of random bytes with the specified length - printed as url-safe base64
 
 ```
 USAGE
   $ cryppo genkey
 
 OPTIONS
-  -l, --length=length  length of the key to generate (defaults to 32 - cryppo's default)
+  -l, --length=length  [default: 32] length of the key in bytes to generate (defaults to 32 bytes - cryppo's default)
 
 EXAMPLES
   cryppo genkey
-  cryppo genkey -l 64
+  cryppo genkey -l 16
 ```
 
-_See code: [src/commands/genkey.ts](https://github.com/Meeco/cryppo-cli/blob/v0.2.0/src/commands/genkey.ts)_
+_See code: [src/commands/genkey.ts](https://github.com/Meeco/cryppo-cli/blob/v0.2.1/src/commands/genkey.ts)_
 
 ## `cryppo genkeypair`
 
@@ -142,7 +146,7 @@ EXAMPLE
   cryppo genkeypair -p private.pem -P public.pem
 ```
 
-_See code: [src/commands/genkeypair.ts](https://github.com/Meeco/cryppo-cli/blob/v0.2.0/src/commands/genkeypair.ts)_
+_See code: [src/commands/genkeypair.ts](https://github.com/Meeco/cryppo-cli/blob/v0.2.1/src/commands/genkeypair.ts)_
 
 ## `cryppo help [COMMAND]`
 
@@ -180,7 +184,7 @@ EXAMPLE
   cryppo sign -p private.pem my_file.txt my_file.signed.txt
 ```
 
-_See code: [src/commands/sign.ts](https://github.com/Meeco/cryppo-cli/blob/v0.2.0/src/commands/sign.ts)_
+_See code: [src/commands/sign.ts](https://github.com/Meeco/cryppo-cli/blob/v0.2.1/src/commands/sign.ts)_
 
 ## `cryppo verify FILE DESTINATION`
 
@@ -201,5 +205,6 @@ EXAMPLE
   cryppo verify -P public.pem my_file.signed.txt my_file.txt
 ```
 
-_See code: [src/commands/verify.ts](https://github.com/Meeco/cryppo-cli/blob/v0.2.0/src/commands/verify.ts)_
+_See code: [src/commands/verify.ts](https://github.com/Meeco/cryppo-cli/blob/v0.2.1/src/commands/verify.ts)_
+
 <!-- commandsstop -->

--- a/src/commands/genkey.ts
+++ b/src/commands/genkey.ts
@@ -3,14 +3,17 @@ import { Command, flags } from '@oclif/command';
 import { handleException } from '../handle-exception';
 
 export default class Genkey extends Command {
-  static description = 'Generate a new (random) encryption key - printed as base64 encoded';
+  static description =
+    'Generate a new encryption key of random bytes with the specified length - printed as url-safe base64';
 
-  static examples = ['cryppo genkey', 'cryppo genkey -l 64'];
+  static examples = ['cryppo genkey', 'cryppo genkey -l 16'];
 
   static flags = {
     length: flags.integer({
       char: 'l',
-      description: "length of the key to generate (defaults to 32 - cryppo's default)"
+      default: 32,
+      description:
+        "length of the key in bytes to generate (defaults to 32 bytes - cryppo's default)"
     })
   };
 
@@ -19,6 +22,13 @@ export default class Genkey extends Command {
       const { flags } = this.parse(Genkey);
 
       const { length } = flags;
+
+      if (![128, 192, 256].includes(length / 8)) {
+        this.warn(
+          `You have specified a key length of ${length} bytes - AES only supports 128, 192 or 256 bit keys`
+        );
+      }
+
       const key = await generateRandomKey(length);
       this.log('URL-Safe Base64 encoded key:');
       this.log(encodeSafe64(key));

--- a/test/commands/genkey.test.ts
+++ b/test/commands/genkey.test.ts
@@ -18,8 +18,8 @@ describe('genkey', () => {
     .stderr()
     .command(['genkey', '-l', '4'])
     .it('Provides a warning if an AES key length is specified', ctx => {
-      expect(ctx.stderr).to.contain(
-        'Warning: You have specified a key length of 4 bytes - AES only supports 128, 192 or 256 bit keys'
-      );
+      expect(ctx.stderr).to.contain('Warning: You have specified a key length of 4 bytes');
+      expect(ctx.stderr).to.contain('AES only supports');
+      expect(ctx.stderr).to.contain('128, 192 or 256 bit keys');
     });
 });

--- a/test/commands/genkey.test.ts
+++ b/test/commands/genkey.test.ts
@@ -13,4 +13,13 @@ describe('genkey', () => {
       expect(ctx.stdout).to.contain('URL-Safe Base64 encoded key:');
       expect(ctx.stdout).to.contain(base64EncodedKey);
     });
+
+  test
+    .stderr()
+    .command(['genkey', '-l', '4'])
+    .it('Provides a warning if an AES key length is specified', ctx => {
+      expect(ctx.stderr).to.contain(
+        'Warning: You have specified a key length of 4 bytes - AES only supports 128, 192 or 256 bit keys'
+      );
+    });
 });


### PR DESCRIPTION
Was pointed out that the example length in genkey wasn't even a valid AES key length. It also wasn't clear that the key length to be provided is in bytes not bits (cryppo handles all its length values in bytes).

I've updated the docs for clarity and also print a warning if a key length that is invalid for AES encryption is provided.