### PR TITLE
Fix build errors with latest sinon

### DIFF
--- a/test/commands/decrypt.test.ts
+++ b/test/commands/decrypt.test.ts
@@ -9,6 +9,8 @@ describe('decrypt', () => {
     'Aes256Gcm.gSAByGMq4edzM0U=.LS0tCml2OiAhYmluYXJ5IHwtCiAgaW1QL09qMWZ6eWw0cmwwSgphdDogIWJpbmFyeSB8LQogIE5SbjZUQXJ2bitNS1Z5M0FpZEpmWlE9PQphZDogbm9uZQo=';
   const rsaEncryptedValue = readFileSync(join(__dirname, './rsa_encrypted'), 'utf-8');
   const privateKeyPem = readFileSync(join(__dirname, './test_private_key.pem'), 'utf-8');
+  const fileStub: any = path =>
+    path === 'id_rsa' ? Promise.resolve(stringAsBinaryBuffer(privateKeyPem)) : Promise.reject();
   const base64Key = 'vm8CjugMda2zdjsI9W25nH-CY-84DDYoBxTFLwfKLDk=';
   test
     .stdout()
@@ -19,9 +21,7 @@ describe('decrypt', () => {
 
   test
     .stdout()
-    .stub(file, 'readFileAsBuffer', path =>
-      path === 'id_rsa' ? Promise.resolve(stringAsBinaryBuffer(privateKeyPem)) : Promise.reject()
-    )
+    .stub(file, 'readFileAsBuffer', fileStub)
     .command(['decrypt', '-p', 'id_rsa', '-s', rsaEncryptedValue])
     .it('Decrypts a value with an RSA private key', ctx => {
       expect(ctx.stdout).to.contain('hello world');

--- a/test/commands/encrypt.test.ts
+++ b/test/commands/encrypt.test.ts
@@ -8,7 +8,7 @@ const mockEncryptedValue = 'Aes256Gcm.gSAByGMq4edzM0U=.LS0tCml';
 describe('encrypt', () => {
   const mockKey = cryppo.encodeSafe64('mockKey');
   test
-    .stub(cryppo, 'encryptWithKey', mockEncrypt)
+    .stub(cryppo, 'encryptWithKey', mockEncrypt as any)
     .stdout()
     .command(['encrypt', '-k', mockKey, '-v', 'My Secret Data'])
     .it('Encrypts data with an AES key', ctx => {
@@ -16,12 +16,11 @@ describe('encrypt', () => {
     });
 
   test
-    .stub(cryppo, 'encryptWithPublicKey', ({ data, publicKeyPem }) =>
+    .stub(cryppo, 'encryptWithPublicKey', (({ data, publicKeyPem }) =>
       Promise.resolve({
         serialized: `${data} encrypted w/ ${publicKeyPem}`
-      })
-    )
-    .stub(file, 'readFileAsBuffer', path => Promise.resolve(`${path} contents`))
+      })) as any)
+    .stub(file, 'readFileAsBuffer', (path => Promise.resolve(`${path} contents`)) as any)
     .stdout()
     .command(['encrypt', '-P', 'id_rsa.pub', '-v', 'My Secret Data'])
     .it('Encrypts data with an RSA public key', ctx => {

--- a/test/commands/genkeypair.test.ts
+++ b/test/commands/genkeypair.test.ts
@@ -12,7 +12,7 @@ describe('genkeypair', () => {
   test
     // Mocked so we get a deterministic value for testing
     .stub(cryppo, 'generateRSAKeyPair', stub().returns(Promise.resolve(mockKey)))
-    .stub(util, 'promisify', fn => fn)
+    .stub(util, 'promisify', (fn => fn) as any)
     .stub(fs, 'writeFile', stub().returns(Promise.resolve()))
     .stdout()
     .command(['genkeypair', '-b', '2048', '-p', 'id_rsa', '-P', 'id_rsa.pub'])


### PR DESCRIPTION
Latest sinon actually type checks your mock methods so I'm type-casting most of the stubs to `any` much like was done for the SDK/Meeco CLI.